### PR TITLE
Configuration 'compile' is obsolete

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.scottyab:rootbeer-lib:0.0.6'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.scottyab:rootbeer-lib:0.0.6'
 }


### PR DESCRIPTION
 Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.